### PR TITLE
dennis/stg-1343/open_api_typos

### DIFF
--- a/sdk-api.yaml
+++ b/sdk-api.yaml
@@ -687,7 +687,7 @@ components:
           type: string
           nullable: true
           example: "pro"
-        organizationIdentifer:
+        organizationIdentifier:
           description: The organization identifier to which this user belongs.
           type: string
           nullable: false


### PR DESCRIPTION
I've been scratching my head why is it that `organizationIdentifier` is always `null`. It turns out that there's a typo in the OpenAPI definition, but our controller is correct.